### PR TITLE
Fix positional args parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ module.exports = function (args, opts) {
           return flags.bools[x];
       });
     }
-
+    var posInd = 0
     for (var i = 0; i < args.length; i++) {
         var arg = args[i];
         
@@ -186,9 +186,10 @@ module.exports = function (args, opts) {
         }
         else {
             if (!flags.unknownFn || flags.unknownFn(arg) !== false) {
-                var asString = flags.strings[i] || flags.strings['_'] || !isNumber(arg);
+                var asString = flags.strings[posInd] || flags.strings['_'] || !isNumber(arg);
                 argv._.push(asString ? arg : Number(arg));
             }
+            posInd++;
             if (opts.stopEarly) {
                 argv._.push.apply(argv._, args.slice(i + 1));
                 break;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minimist",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "parse argument options",
   "main": "index.js",
   "devDependencies": {

--- a/test/parse.js
+++ b/test/parse.js
@@ -101,6 +101,11 @@ test('stringArgs', function (t) {
     s = parse(['11', '22', '33'], {string: [0, 2]})._;
     t.deepEqual(s, ['11', 22, '33'])
     
+    s = parse(
+        ['--foo', '1', '11', '--bar', '4', '22', '33'],
+        {string: [0, 2]})._;
+    t.deepEqual(s, ['11', 22, '33'])
+
     t.end();
 });
 


### PR DESCRIPTION
Improves feature https://github.com/mulesoft/minimist/pull/1
Fixes https://github.com/mulesoft/anypoint-cli/issues/79

See this comment and further for issue description https://github.com/mulesoft/anypoint-cli/issues/71#issuecomment-294058448

Issue in short: when positional args are provided after options their `string` option is not working properly. 